### PR TITLE
License year update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 BYOND
+Copyright (c) 2021 BYOND
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
** Changes **
The license file is out of date for a year. Now it's mid-2021, not 2020, as in the file. Corrected.

1. In the license file, the year was changed from 2020 to 2021.